### PR TITLE
Outlook fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar, export, outlook
 Requires at least: 4.9
-Tested up to: 5.8.2
+Tested up to: 5.8.3
 Requires PHP: 5.6
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -30,6 +30,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.1.1] 2022-01-24 =
+
+* Fix - Removed time zone offset from the start and end times of the date because Outlook deeplink doesn't support it any longer.
 
 = [1.1.0] 2021-12-20 =
 

--- a/src/Tribe/Plugin.php
+++ b/src/Tribe/Plugin.php
@@ -19,7 +19,7 @@ class Plugin extends tad_DI52_ServiceProvider {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.1.0';
+	const VERSION = '1.1.1';
 
 	/**
 	 * Stores the base slug for the plugin.

--- a/src/Tribe/Plugin.php
+++ b/src/Tribe/Plugin.php
@@ -112,8 +112,8 @@ class Plugin extends tad_DI52_ServiceProvider {
 		$path = '/calendar/action/compose';
 		$rrv = 'addevent';
 
-		$startdt = $event->start_date_utc;
-		$enddt = $event->end_date_utc;
+		$startdt = $event->start_date;
+		$enddt = $event->end_date;
 
 		/**
 		 * If event is an all day event, then adjust the end time.
@@ -126,9 +126,11 @@ class Plugin extends tad_DI52_ServiceProvider {
 				. date( 'P', strtotime( $enddt ) );
 		} else {
 			$enddt = date( 'c', strtotime( $enddt ) ); // 17 chars
+			$enddt = substr( $enddt, 0, strlen( $enddt )-6 );
 		}
 
 		$startdt = date( 'c', strtotime( $startdt ) );
+		$startdt = substr( $startdt, 0, strlen( $startdt )-6 );
 
 		$subject = $this->space_replace_and_encode( strip_tags( $event->post_title ) ); // 8+ chars
 

--- a/src/Tribe/Plugin.php
+++ b/src/Tribe/Plugin.php
@@ -122,8 +122,8 @@ class Plugin extends tad_DI52_ServiceProvider {
 		if ( $event->all_day ) {
 			$enddt = date( 'Y-m-d', strtotime( $enddt ) )
 				. 'T'
-				. date( 'H:i:s', strtotime( $startdt ) )
-				. date( 'P', strtotime( $enddt ) );
+				. date( 'H:i:s', strtotime( $startdt ) );
+				//. date( 'P', strtotime( $enddt ) );
 		} else {
 			$enddt = date( 'c', strtotime( $enddt ) ); // 17 chars
 			$enddt = substr( $enddt, 0, strlen( $enddt )-6 );

--- a/tec-labs-outlook-export-buttons.php
+++ b/tec-labs-outlook-export-buttons.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/outlook-export-buttons
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-outlook-export-buttons
  * Description:       The extension adds Export to Outlook Live / 365 buttons to the single event page.
- * Version:           1.1.0
+ * Version:           1.1.1
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version


### PR DESCRIPTION
Quickfix: Removed time zone offset from the start and end times of the date because Outlook deeplink doesn't support it any longer.